### PR TITLE
remove versioneer from standard development environment

### DIFF
--- a/anaconda-project.yml
+++ b/anaconda-project.yml
@@ -68,6 +68,3 @@ env_specs:
     - pytest
     - pytest-cov
     - python-dotenv
-    - versioneer
-
-


### PR DESCRIPTION
It's only needed at build time now.